### PR TITLE
v0.4.2: Add pagination and async processing of requests/responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aars"
-version = "0.3.4"
+version = "0.4.1"
 authors = [
   { name="Mike Hukiewitz", email="mike.hukiewitz@robotter.ai" },
 ]
@@ -19,7 +19,7 @@ classifiers = [
 
 [dependencies]
 pydantic = "^1.8.2"
-aleph_client = "^0.5.0"
+aleph-sdk-python = "^0.6.0"
 
 [project.urls]
 "Homepage" = "https://github.com/aleph-im/active-record-sdk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aars"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
   { name="Mike Hukiewitz", email="mike.hukiewitz@robotter.ai" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pydantic~=1.9.0
-certifi~=2022.6.15
-aiohttp~=3.8.1
-pytest~=7.1.2
+pydantic
+certifi
+aiohttp
+pytest
 pytest-asyncio
 pytest-xdist
-aleph-sdk-python~=0.6.0
+aleph-sdk-python==0.6.0

--- a/src/aars/exceptions.py
+++ b/src/aars/exceptions.py
@@ -4,6 +4,18 @@ class AlephError(Exception):
     pass
 
 
+class AlreadyUsedError(AlephError):
+    """Exception raised when a PageableResponse has already been used."""
+
+    def __init__(
+        self,
+        message="PageableResponse has already been iterated over. It is recommended to "
+        "to store the result of all() or page() or to create a new query.",
+    ):
+        self.message = message
+        super().__init__(self.message)
+
+
 class AlreadyForgottenError(AlephError):
     def __init__(
         self,

--- a/src/aars/utils.py
+++ b/src/aars/utils.py
@@ -1,8 +1,27 @@
 import operator
 from itertools import *
-from typing import AsyncIterator, List, TypeVar, OrderedDict, Generic, Type, Optional
+from typing import (
+    AsyncIterator,
+    List,
+    TypeVar,
+    OrderedDict,
+    Generic,
+    Type,
+    Optional,
+    Awaitable,
+    Callable,
+    Tuple,
+    Dict,
+)
+
+from .exceptions import AlreadyUsedError
 
 T = TypeVar("T")
+
+
+class EmptyAsyncIterator(AsyncIterator[T]):
+    async def __anext__(self) -> T:
+        raise StopAsyncIteration
 
 
 class IndexQuery(OrderedDict, Generic[T]):
@@ -19,6 +38,94 @@ class IndexQuery(OrderedDict, Generic[T]):
         return IndexQuery(
             self.record_type, **{key: arg for key, arg in self.items() if key in keys}
         )
+
+
+class PageableResponse(AsyncIterator[T], Generic[T]):
+    """
+    A wrapper around an AsyncIterator that allows for easy pagination and iteration, while also preventing multiple
+    iterations. This is mainly used for nicer syntax when not using the async generator syntax.
+    """
+    record_generator: AsyncIterator[T]
+    used: bool = False
+
+    def __init__(self, record_generator: AsyncIterator[T]):
+        self.record_generator = record_generator
+
+    async def all(self) -> List[T]:
+        if self.used:
+            raise AlreadyUsedError()
+        self.used = True
+        return await async_iterator_to_list(self.record_generator)
+
+    async def page(self, page: int, page_size: int) -> List[T]:
+        if self.used:
+            raise AlreadyUsedError()
+        self.used = True
+        return await async_iterator_to_list(
+            self.record_generator, page * page_size, page_size
+        )
+
+    async def first(self) -> Optional[T]:
+        if self.used:
+            raise AlreadyUsedError()
+        self.used = True
+        return await self.record_generator.__anext__()
+
+    def __anext__(self) -> Awaitable[T]:
+        try:
+            self.used = True
+            return self.record_generator.__anext__()
+        except StopAsyncIteration:
+            raise
+
+
+class PageableRequest(AsyncIterator[T], Generic[T]):
+    """
+    A wrapper around a request that returns a PageableResponse. Useful if performance improvements can be obtained by
+    passing page and page_size parameters to the request.
+    """
+
+    func: Callable[..., AsyncIterator[T]]
+    args: Tuple
+    kwargs: Dict
+    response: Optional[PageableResponse] = None
+
+    def __init__(self, func: Callable[..., AsyncIterator[T]], *args, **kwargs):
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def __await__(self):
+        self.response = PageableResponse(self.func(*self.args, **self.kwargs))
+        return self.response
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        self._prepare_response()
+        assert self.response is not None
+        return self.response
+
+    def __anext__(self) -> Awaitable[T]:
+        return PageableResponse(self.func(*self.args, **self.kwargs, page=1, page_size=20)).__anext__()
+
+    def _prepare_response(self):
+        if self.response is not None:
+            return self.response
+        self.response = PageableResponse(self.func(*self.args, **self.kwargs, page=1, page_size=20))
+
+    async def all(self) -> List[T]:
+        return await PageableResponse(
+            self.func(*self.args, **self.kwargs, page=1, page_size=20)
+        ).all()
+
+    async def page(self, page, page_size) -> List[T]:
+        return await PageableResponse(
+            self.func(*self.args, **self.kwargs, page=page, page_size=page_size)
+        ).page(page=page, page_size=page_size)
+
+    async def first(self) -> Optional[T]:
+        return await PageableResponse(
+            self.func(*self.args, **self.kwargs, page=1, page_size=20)
+        ).first()
 
 
 def subslices(seq):
@@ -45,16 +152,20 @@ def possible_index_names(seq):
 
 
 async def async_iterator_to_list(
-    iterator: AsyncIterator[T], count: Optional[int] = None
+    iterator: AsyncIterator[T], skip: int = 0, count: Optional[int] = None
 ) -> List[T]:
     """
     Return a list from an async iterator.
     """
-    if count is None:
+    if count is None and skip == 0:
         return [item async for item in iterator]
     else:
         items = []
         async for item in iterator:
+            if skip > 0:
+                skip -= 1
+                continue
+
             items.append(item)
             if len(items) == count:
                 break

--- a/tests/fetch_all.py
+++ b/tests/fetch_all.py
@@ -1,11 +1,13 @@
 import pytest
 import asyncio
 
-from aleph_client.asynchronous import get_fallback_session
+from aleph.sdk import AuthenticatedAlephClient
+from aleph.sdk.chains.ethereum import get_fallback_account
+from aleph.sdk.conf import settings
 
 from src.aars import Record, AARS
 
-AARS(session=get_fallback_session())
+AARS(session=AuthenticatedAlephClient(get_fallback_account(), settings.API_HOST))
 
 
 @pytest.fixture(scope="session")
@@ -21,7 +23,7 @@ class Book(Record):
 
 @pytest.mark.asyncio
 async def test_fetch_all():
-    books = await Book.fetch_all()
+    books = await Book.fetch_objects()
     print(len(books))
     assert len(books) > 0
     for book in books:


### PR DESCRIPTION
- Changed the interface such that all _fetch_-like functions are now returning `PageableResponse` or `PageableRequest` objects, which can be used to either return:
  - `.all()`
  - `.first()`
  - or `.page(page, page_size)`
- Upgrade to latest version of aleph-sdk-python and use `ItemHash` object type wherever applicable